### PR TITLE
s3を使わないようにした

### DIFF
--- a/packages/server/src/handler/comment.ts
+++ b/packages/server/src/handler/comment.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from "fastify"
 import { ResponseBody } from "../util/schema"
 import { Comment, CommentDataType } from "../entity/Comment"
-import { MultipartFile, MultipartValue } from "fastify-multipart"
+import { MultipartValue } from "fastify-multipart"
 import { File } from "../entity/File"
 import { Stamp } from "../entity/Stamp"
 import { connection } from "../index"
@@ -19,7 +19,7 @@ export const commentHandler = async (server: FastifyInstance) => {
     Params: { fileId: string; stampId: number }
     Body: {
       dataType: MultipartValue<CommentDataType>
-      content: MultipartValue<string> | MultipartFile
+      content: MultipartValue<string>
       title?: MultipartValue<string>
     }
     Reply: ResponseBody
@@ -58,7 +58,7 @@ export const buildComment = async (
   dataType: CommentDataType,
   author: User,
   stamp: Stamp,
-  content: MultipartValue<string> | MultipartFile,
+  content: MultipartValue<string>,
   title?: string,
 ): Promise<Comment> => {
   const comment = new Comment()
@@ -69,25 +69,27 @@ export const buildComment = async (
   switch (dataType) {
     // save text file
     case CommentDataType.TEXT:
-      comment.content = (content as MultipartValue<string>).value
+      // comment.content = (content as MultipartValue<string>).value
+      comment.content = content.value
       break
 
     // save audio file
     case CommentDataType.AUDIO: {
-      const audio = content as MultipartFile
-      const filename = audio.filename
-      if (!filename) {
-        const e = createError(
-          ERR_INVALID_PAYLOAD,
-          "`content` must be sent.",
-          400,
-        )
-        throw new e()
-      }
-      const buffer = await audio.toBuffer()
-
-      const { fileUrl } = await storage.save("audio", filename, buffer)
-      comment.content = fileUrl
+      // const audio = content as MultipartFile
+      // const filename = audio.filename
+      // if (!filename) {
+      //   const e = createError(
+      //     ERR_INVALID_PAYLOAD,
+      //     "`content` must be sent.",
+      //     400,
+      //   )
+      //   throw new e()
+      // }
+      // const buffer = await audio.toBuffer()
+      //
+      // const { fileUrl } = await storage.save("audio", filename, buffer)
+      // comment.content = fileUrl
+      comment.content = content.value
 
       if (title) comment.title = title
 

--- a/packages/server/src/handler/file.ts
+++ b/packages/server/src/handler/file.ts
@@ -95,26 +95,28 @@ export const fileHandler = async (server: FastifyInstance) => {
   )
 
   server.post<{
-    Body: { name: MultipartValue<string>; file: MultipartFile }
+    Body: { name: MultipartValue<string>; file: MultipartValue<string> }
     Reply: ResponseBody
   }>("/file", async (req, res) => {
-    const file = req.body.file
-    if (!file.filename) {
-      const e = createError(ERR_INVALID_PAYLOAD, "`file` should be sent.", 400)
-      throw new e()
-    }
-    const buffer = await file.toBuffer()
-    const filename = file.filename
-
-    const { fileUrl, thumbnailUrl } = await server
-      .storage()
-      .save("file", filename, buffer)
+    // const file = req.body.file
+    // if (!file.filename) {
+    //   const e = createError(ERR_INVALID_PAYLOAD, "`file` should be sent.", 400)
+    //   throw new e()
+    // }
+    // const buffer = await file.toBuffer()
+    // const filename = file.filename
+    //
+    // const { fileUrl, thumbnailUrl } = await server
+    //   .storage()
+    //   .save("file", filename, buffer)
 
     const fileModel = new File()
     fileModel.name = req.body.name.value
-    fileModel.url = fileUrl
-    fileModel.thumbnail =
-      thumbnailUrl ?? "Thumbnail is generated only in production mode."
+    // fileModel.url = fileUrl
+    fileModel.url = req.body.file.value
+    // fileModel.thumbnail =
+    //   thumbnailUrl ?? "Thumbnail is generated only in production mode."
+    fileModel.thumbnail = "Thumbnail is generated only when use s3."
     fileModel.author = req.currentUser
     fileModel.updated_by = req.currentUser
 

--- a/packages/server/src/handler/stamp.ts
+++ b/packages/server/src/handler/stamp.ts
@@ -8,7 +8,7 @@ import {
   buildCommentResponse,
   buildStampResponse,
 } from "../util/responseBuilders"
-import { MultipartFile, MultipartValue } from "fastify-multipart"
+import { MultipartValue } from "fastify-multipart"
 import { buildComment } from "./comment"
 import { registerFirebaseAuth } from "../util/auth"
 
@@ -22,7 +22,7 @@ export const stampHandler = async (server: FastifyInstance) => {
       x: MultipartValue<number>
       y: MultipartValue<number>
       dataType: MultipartValue<CommentDataType>
-      content: MultipartValue<string> | MultipartFile
+      content: MultipartValue<string>
       title?: MultipartValue<string>
     }
     Reply: ResponseBody


### PR DESCRIPTION
close #xxx

## やったこと
- 本番環境(ECS)でのs3の使用がうまくできなかったため、s3を使わないでフロントでfirebase storageを使うようにした

<!--
### スクリーンショット
-->

<!--
## やっていないこと
-->

<!--
## 動作確認方法
-->

<!--
# 補足・参考リンク
-->