### PR TITLE
ファイルアップモーダルで選択しているファイルをわかるようにする

### DIFF
--- a/packages/front/src/components/organisms/fileUploader.tsx
+++ b/packages/front/src/components/organisms/fileUploader.tsx
@@ -43,6 +43,28 @@ export const FileUploader: NextPage = () => {
     router.push(`/${res.file.id}`)
   }
 
+  const fileUi = (
+    <div className="flex items-center">
+      <div className="container mx-auto p-9 bg-white max-w-sm rounded-2xl overflow-hidden shadow-xl hover:shadow-2xl transition duration-300">
+        <div className="flex justify-between items-center">
+          <div className="pr-2">
+            <h1 className="mt-5 text-2xl font-semibold text-gray-500">
+              {pdf?.name}
+            </h1>
+            <p className="mt-2 text-gray-500">{pdf?.size} bytes</p>
+          </div>
+          <div>
+            <button
+              className="text-white text-md font-semibold bg-red-400 py-2 px-2 rounded-lg shadow-md hover:shadow-lg transition duration-500 transform-gpu hover:scale-110"
+              onClick={() => setPdf(null)}
+            >
+              remove
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
   return (
     <>
       <div className="relative flex items-center justify-center sm:px-6">
@@ -69,14 +91,18 @@ export const FileUploader: NextPage = () => {
               <div className="flex items-center justify-center w-full">
                 <label className="flex flex-col w-full p-10 text-center border-4 border-dashed rounded-lg h-60 group">
                   <div className="flex flex-col items-center justify-center w-full h-full text-center ">
-                    <p className="text-gray-500 pointer-none ">
-                      <span className="text-sm">Drag and drop</span> files here{" "}
-                      <br /> or{" "}
-                      <div className="text-blue-600 hover:underline">
-                        select a file
-                      </div>{" "}
-                      from your computer
-                    </p>
+                    {pdf ? (
+                      <> {fileUi}</>
+                    ) : (
+                      <p className="text-gray-500 pointer-none ">
+                        <span className="text-sm">Drag and drop</span> files
+                        here <br /> or{" "}
+                        <div className="text-blue-600 hover:underline">
+                          select a file
+                        </div>{" "}
+                        from your computer
+                      </p>
+                    )}
                   </div>
                   <input
                     type="file"

--- a/packages/front/src/components/organisms/fileUploader.tsx
+++ b/packages/front/src/components/organisms/fileUploader.tsx
@@ -72,13 +72,9 @@ export const FileUploader: NextPage = () => {
                     <p className="text-gray-500 pointer-none ">
                       <span className="text-sm">Drag and drop</span> files here{" "}
                       <br /> or{" "}
-                      <a
-                        href=""
-                        id=""
-                        className="text-blue-600 hover:underline"
-                      >
+                      <div className="text-blue-600 hover:underline">
                         select a file
-                      </a>{" "}
+                      </div>{" "}
                       from your computer
                     </p>
                   </div>


### PR DESCRIPTION
close #77 

## やったこと
ファイルアップモーダルで選択しているファイルをわかるようにする

### スクリーンショット
**アップロード前**
<img width="477" alt="スクリーンショット 2021-10-30 11 19 48" src="https://user-images.githubusercontent.com/77659783/139517165-69c793ec-8384-4d45-aeed-e230ae83e2a2.png">


**アップロード後**
<img width="498" alt="スクリーンショット 2021-10-30 11 19 41" src="https://user-images.githubusercontent.com/77659783/139517169-dd0d7c03-4f35-4351-9af1-df23401e0753.png">

<!--
## やっていないこと
-->

<!--
## 動作確認方法
-->

<!--
# 補足・参考リンク
-->