### PR TITLE
APIレスポンスのフィールド名のタイポ修正

### DIFF
--- a/packages/front/src/domain/comment.ts
+++ b/packages/front/src/domain/comment.ts
@@ -1,10 +1,21 @@
 import { User } from "@domain/user"
 
-export type Comment = {
+export type Comment = AudioComment | TextComment
+
+export type AudioComment = {
   id: string
-  dataType: "audio" | "text"
+  dataType: "audio"
   content: string
   author: User
   postedAt: string
   title: string
+}
+
+export type TextComment = {
+  id: string
+  dataType: "text"
+  content: string
+  author: User
+  postedAt: string
+  title?: undefined
 }

--- a/packages/front/src/domain/comment.ts
+++ b/packages/front/src/domain/comment.ts
@@ -1,21 +1,10 @@
 import { User } from "@domain/user"
 
-export type Comment = AudioComment | TextComment
-
-export type AudioComment = {
+export type Comment = {
   id: string
-  dataType: "audio"
+  dataType: "audio" | "text"
   content: string
   author: User
   postedAt: string
   title: string
-}
-
-export type TextComment = {
-  id: string
-  dataType: "text"
-  content: string
-  author: User
-  postedAt: string
-  title?: undefined
 }

--- a/packages/front/src/useCase/file/fileUseCase.ts
+++ b/packages/front/src/useCase/file/fileUseCase.ts
@@ -119,7 +119,6 @@ export class FileUseCase implements FileUseCaseInterface {
         id: `${stamp.id}`,
         comments: stamp.comments.map((comment) => ({
           ...comment,
-          dataType: comment.dataType,
           id: `${comment.id}`,
         })),
       })),
@@ -156,7 +155,6 @@ export class FileUseCase implements FileUseCaseInterface {
       comments: res.comments.map((comment) => ({
         ...comment,
         id: `${comment.id}`,
-        dataType: comment.dataType,
       })),
     }
   }

--- a/packages/front/src/useCase/file/fileUseCase.ts
+++ b/packages/front/src/useCase/file/fileUseCase.ts
@@ -106,8 +106,7 @@ export class FileUseCase implements FileUseCaseInterface {
     const res = await this.restClient.get<FileDataSnapshot[]>(`/file`)
     return res.map((file) => ({
       ...file,
-      // @ts-ignore
-      updatedBy: file.updatedBy ?? file.updatedBt,
+      updatedBy: file.updatedBy,
     }))
   }
 
@@ -115,14 +114,12 @@ export class FileUseCase implements FileUseCaseInterface {
     const res = await this.restClient.get<GetDetailResponse>(`/file/${fileId}`)
     return {
       ...res,
-      // @ts-ignore
       stamps: res.stamps.map((stamp) => ({
         ...stamp,
         id: `${stamp.id}`,
         comments: stamp.comments.map((comment) => ({
           ...comment,
-          // @ts-ignore
-          dataType: comment.dataType ?? comment.dateType,
+          dataType: comment.dataType,
           id: `${comment.id}`,
         })),
       })),
@@ -156,12 +153,10 @@ export class FileUseCase implements FileUseCaseInterface {
     return {
       ...res,
       id: `${res.id}`,
-      // @ts-ignore
       comments: res.comments.map((comment) => ({
         ...comment,
         id: `${comment.id}`,
-        // @ts-ignore
-        dataType: comment.dataType ?? comment.dateType,
+        dataType: comment.dataType,
       })),
     }
   }
@@ -187,7 +182,7 @@ export class FileUseCase implements FileUseCaseInterface {
       `/file/${fileId}/stamp/${stampId}/comment`,
       form,
     )
-    // @ts-ignore
-    return { ...res, id: `${res.id}`, dataType: res.dataType ?? res.dateType }
+
+    return { ...res, id: `${res.id}` }
   }
 }

--- a/packages/server/src/handler/file.ts
+++ b/packages/server/src/handler/file.ts
@@ -39,7 +39,7 @@ export const fileHandler = async (server: FastifyInstance) => {
         type: f.fileType(req.currentUser),
         file: buildFileResponse(f),
         updatedAt: f.updated_at,
-        updatedBt: buildUserResponse(f.updated_by),
+        updatedBy: buildUserResponse(f.updated_by),
       })),
     })
   })

--- a/packages/server/src/util/responseBuilders.ts
+++ b/packages/server/src/util/responseBuilders.ts
@@ -27,7 +27,7 @@ type StampResponse = {
 
 type CommentResponse = {
   id: number
-  dateType: CommentDataType
+  dataType: CommentDataType
   content: string
   title?: string
   author: UserResponse
@@ -74,7 +74,7 @@ export const buildStampResponse = async (
 export const buildCommentResponse = (comment: Comment): CommentResponse => {
   const response: CommentResponse = {
     id: comment.id,
-    dateType: comment.data_type,
+    dataType: comment.data_type,
     content: comment.content,
     author: buildUserResponse(comment.author),
     postedAt: comment.posted_at,


### PR DESCRIPTION
close #74 
close #75 

## やったこと
- APIレスポンスのフィールド名ががタイポしていたので修正
- フロントの方も直したんですけど、変なところあったら教えてください

<!--
### スクリーンショット
-->

<!--
## やっていないこと
-->

<!--
## 動作確認方法
-->

<!--
# 補足・参考リンク
-->