### PR TITLE
Googlefontを適用

### DIFF
--- a/packages/front/src/pages/_document.tsx
+++ b/packages/front/src/pages/_document.tsx
@@ -1,0 +1,24 @@
+import Document, { Html, Head, Main, NextScript } from "next/document"
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic:wght@300;400;700&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/packages/front/src/pages/_document.tsx
+++ b/packages/front/src/pages/_document.tsx
@@ -6,7 +6,11 @@ class MyDocument extends Document {
       <Html>
         <Head>
           <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin="true"
+          />
           <link
             href="https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic:wght@300;400;700&display=swap"
             rel="stylesheet"

--- a/packages/front/tailwind.config.js
+++ b/packages/front/tailwind.config.js
@@ -1,5 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires, no-undef
 const plugin = require("tailwindcss/plugin")
+// eslint-disable-next-line @typescript-eslint/no-var-requires, no-undef
+const defaultTheme = require("tailwindcss/defaultTheme")
 /** @type {import('@types/tailwindcss/tailwind-config').TailwindConfig} */
 // eslint-disable-next-line no-undef
 module.exports = {
@@ -22,6 +24,9 @@ module.exports = {
       },
       animation: {
         "ping-slow": "ping 2s cubic-bezier(0, 0, 0.2, 1) infinite",
+      },
+      fontFamily: {
+        sans: ["Zen Maru Gothic", ...defaultTheme.fontFamily.sans],
       },
     },
   },


### PR DESCRIPTION
close #73 

## やったこと
- Zen Maru Gothic（Google font）の導入

![image](https://user-images.githubusercontent.com/38308823/139647885-040da420-9f96-4046-be1b-f338c9637b17.png)

<!--
### スクリーンショット
-->

<!--
## やっていないこと
-->

<!--
## 動作確認方法
-->

<!--
# 補足・参考リンク
-->