### PR TITLE
ローディングページを実装

### DIFF
--- a/packages/front/src/components/organisms/listElement.tsx
+++ b/packages/front/src/components/organisms/listElement.tsx
@@ -4,7 +4,7 @@ import { FileDataSnapshot } from "@domain/fileDataSnapshot"
 import { Play, Share } from "react-feather"
 import { formatTime } from "@lib/formatTime"
 import { Icon } from "@components/atoms/Icon"
-import { useAuth } from "@hooks/useAuth"
+import { useAuthUser } from "@hooks/useAuth"
 import { UrlShareModal } from "./urlShareModal"
 import { Thumbnail } from "@components/atoms/Thumbnail"
 
@@ -84,7 +84,7 @@ export const ListElement: React.VFC<ListElementProps> = ({ file }) => {
 }
 
 const LastUpdateInfo: React.VFC<{ file: FileDataSnapshot }> = ({ file }) => {
-  const currentUser = useAuth()
+  const currentUser = useAuthUser()
   const userName =
     (file.updatedBy ?? file.file.author).id === currentUser?.uid
       ? "あなた"

--- a/packages/front/src/components/organisms/searchInput.tsx
+++ b/packages/front/src/components/organisms/searchInput.tsx
@@ -18,7 +18,7 @@ export const SearchInput: React.VFC<SearchInputProps> = ({ setter, value }) => {
         <Search size={16} />
       </div>
       <input
-        className="w-full bg-transparent border-b-2 border-white focus:outline-none"
+        className="w-full bg-transparent focus:outline-none"
         name="search"
         value={value}
         onChange={handleValueChange}

--- a/packages/front/src/components/pages/Page.tsx
+++ b/packages/front/src/components/pages/Page.tsx
@@ -1,0 +1,34 @@
+import React from "react"
+import Image from "next/image"
+import { useAuthInitialized } from "@hooks/useAuth"
+import { Loader } from "react-feather"
+
+export type PageProps = {
+  children: React.ReactNode
+}
+
+export const Page: React.VFC<PageProps> = ({ children }) => {
+  const authInitialized = useAuthInitialized()
+  if (!authInitialized) {
+    return (
+      <div
+        className="fixed inset-0 z-50 flex flex-col items-center justify-center mb-16"
+        aria-label="ローディング中"
+      >
+        <div className="w-[200px] h-[100px] relative mb-2">
+          <Image
+            src="/logo_black.png"
+            objectFit="contain"
+            className="drag-none object-fit"
+            layout="fill"
+          />
+        </div>
+        <div className="flex items-center justify-center">
+          <Loader className="mr-3 animate-spin-slow" />
+          <p className="font-bold tracking-widest">loading...</p>
+        </div>
+      </div>
+    )
+  }
+  return <>{children}</>
+}

--- a/packages/front/src/contexts/authContext.tsx
+++ b/packages/front/src/contexts/authContext.tsx
@@ -2,21 +2,34 @@ import React, { createContext, useState, useEffect } from "react"
 import firebase from "firebase/auth"
 import { auth } from "@lib/firebase"
 
-export const AuthContext = createContext<firebase.User | null>(null)
+type Auth =
+  | {
+      user: firebase.User | null
+      initialized: true
+    }
+  | {
+      user: null
+      initialized: false
+    }
+
+export const AuthContext = createContext<Auth>({
+  user: null,
+  initialized: false,
+})
 
 type AuthProviderProps = {
   children: React.ReactNode
 }
 
-export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
-  const [user, setUser] = useState<firebase.User | null>(null)
+export const AuthProvider: React.VFC<AuthProviderProps> = ({ children }) => {
+  const [user, setUser] = useState<Auth>({ user: null, initialized: false })
 
   useEffect(() => {
     auth.onAuthStateChanged((user) => {
       if (!user) {
-        setUser(null)
+        setUser({ user: null, initialized: true })
       } else {
-        setUser(user)
+        setUser({ user, initialized: true })
       }
     })
   }, [])

--- a/packages/front/src/hooks/useAuth.ts
+++ b/packages/front/src/hooks/useAuth.ts
@@ -4,3 +4,11 @@ import { AuthContext } from "@contexts/authContext"
 export const useAuth = () => {
   return useContext(AuthContext)
 }
+
+export const useAuthUser = () => {
+  return useAuth().user
+}
+
+export const useAuthInitialized = () => {
+  return useAuth().initialized
+}

--- a/packages/front/src/hooks/useFile.ts
+++ b/packages/front/src/hooks/useFile.ts
@@ -10,7 +10,7 @@ import {
 } from "@useCase/file/fileUseCase"
 import { getClient } from "@lib/restClient/restClient"
 import { errorHandler } from "@lib/ErrorHandler"
-import { useAuth } from "./useAuth"
+import { useAuthUser } from "./useAuth"
 import { getStorageClient } from "@lib/storageClient/storageClient"
 import { MockFileUseCase } from "@mocks/useCase/file/mockFileUseCase"
 
@@ -30,7 +30,7 @@ type UseFile = {
 const USE_MOCK = false
 
 export const useFile = (): UseFile => {
-  const user = useAuth()
+  const user = useAuthUser()
   const apiClient = getClient()
   const storageClient = getStorageClient()
   const fileUseCase =

--- a/packages/front/src/hooks/useRequest.ts
+++ b/packages/front/src/hooks/useRequest.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
-import { useAuth } from "./useAuth"
+import { useAuthUser } from "./useAuth"
 
 export const useRequest = <Response>(
   fetch: (...args: unknown[]) => Promise<Response>,
@@ -11,7 +11,7 @@ export const useRequest = <Response>(
   const [data, setData] = useState<Response>(initData)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<unknown>(null)
-  const user = useAuth()
+  const user = useAuthUser()
 
   useEffect(() => {
     ;(async () => {

--- a/packages/front/src/pages/[fileId].tsx
+++ b/packages/front/src/pages/[fileId].tsx
@@ -10,7 +10,7 @@ import { Share, Plus, Minus, ArrowLeft } from "react-feather"
 import { useRequest } from "@hooks/useRequest"
 import { useFile } from "@hooks/useFile"
 import { useRouter } from "next/router"
-import { useAuth } from "@hooks/useAuth"
+import { useAuthUser } from "@hooks/useAuth"
 import { UrlShareModal } from "@components/organisms/urlShareModal"
 
 const PDFViewer: React.ComponentType<PDFViewerProps> = dynamic(
@@ -31,7 +31,7 @@ const FileDetail: NextPage<Record<string, never>, FileDetailQuery> = () => {
   const router = useRouter()
   const fileId = router.query.fileId as string
   const fileUseCase = useFile()
-  const user = useAuth()
+  const user = useAuthUser()
   const [openShareModal, setOpenShareModal] = useState(false)
 
   const { data: file } = useRequest(

--- a/packages/front/src/pages/_app.tsx
+++ b/packages/front/src/pages/_app.tsx
@@ -6,12 +6,16 @@ import { NextPage } from "next"
 // import authReducer from "@reducers/authReducer";
 // import { authUseCase } from "@useCase/authUseCase";
 import { AuthProvider } from "@contexts/authContext"
+import { Page } from "@components/pages/Page"
 
 const MyApp: NextPage<AppProps> = ({ Component, pageProps }) => {
   return (
     <AuthProvider>
-      <Component {...pageProps} />
+      <Page>
+        <Component {...pageProps} />
+      </Page>
     </AuthProvider>
   )
 }
+
 export default MyApp

--- a/packages/front/src/pages/dashboard/index.tsx
+++ b/packages/front/src/pages/dashboard/index.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState } from "react"
 import { FileUploader } from "@components/organisms/fileUploader"
 import Image from "next/image"
 import { SearchInput } from "@components/organisms/searchInput"
-import { useAuth } from "@hooks/useAuth"
+import { useAuthUser } from "@hooks/useAuth"
 import { useRouter } from "next/router"
 import { useRequest } from "@hooks/useRequest"
 import { useFile } from "@hooks/useFile"
@@ -13,7 +13,7 @@ import { authUseCase } from "@useCase"
 
 const Index: React.VFC = () => {
   const [isOpenModal, setIsOpenModal] = useState(false)
-  const user = useAuth()
+  const user = useAuthUser()
   const router = useRouter()
   const fileUseCase = useFile()
 

--- a/packages/front/src/pages/login.tsx
+++ b/packages/front/src/pages/login.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, FC, useReducer } from "react"
 import { useRouter } from "next/router"
 // import Image from "next/image"
 import authReducer from "@reducers/authReducer"
-import { useAuth } from "@hooks/useAuth"
+import { useAuthUser } from "@hooks/useAuth"
 import { authUseCase } from "@useCase"
 import { useWindowSize } from "@hooks/useWindowSize"
 import dynamic from "next/dynamic"
@@ -16,7 +16,7 @@ const Login: FC = () => {
     authReducer.reducer,
     authReducer.initialState,
   )
-  const user = useAuth()
+  const user = useAuthUser()
   const { width, height } = useWindowSize()
 
   useEffect(() => {

--- a/packages/front/src/useCase/authUseCase.ts
+++ b/packages/front/src/useCase/authUseCase.ts
@@ -31,6 +31,5 @@ export default class AuthUseCase {
   /**ログアウト */
   async logout() {
     await auth.signOut()
-    window.location.reload()
   }
 }

--- a/packages/front/tailwind.config.js
+++ b/packages/front/tailwind.config.js
@@ -22,6 +22,7 @@ module.exports = {
       },
       animation: {
         "ping-slow": "ping 2s cubic-bezier(0, 0, 0.2, 1) infinite",
+        "spin-slow": "spin 4s linear infinite",
       },
     },
   },
@@ -31,18 +32,17 @@ module.exports = {
   plugins: [
     plugin(function ({ addUtilities }) {
       const newUtilities = {
-        ".skew-10deg": {
-          transform: "skewY(-10deg)",
-        },
-        ".skew-15deg": {
-          transform: "skewY(-15deg)",
-        },
         ".text-decoration-transparent": {
           "text-decoration-color": "transparent",
         },
 
         ".text-decoration-auto": {
           "text-decoration-color": "currentColor",
+        },
+        ".drag-none": {
+          "user-drag": "none",
+          "-webkit-user-drag": "none",
+          "-moz-user-select": "none",
         },
       }
 


### PR DESCRIPTION
close #71 

## やったこと
- AuthContextに認証未完了の状態を追加
- useAuthをuseAuthUserにrename
- 認証完了状態を取得するuseAuthInitializedを追加
- ローディングページを実装
- ログアウト後のハードリロードを除去

### スクリーンショット
![image](https://user-images.githubusercontent.com/38308823/140762034-9ed643ea-8e4c-4097-ab94-15b424e2b34b.png)


<!--
## やっていないこと
-->

<!--
## 動作確認方法
-->

<!--
# 補足・参考リンク
-->