### PR TITLE
匿名ユーザーに対応

### DIFF
--- a/packages/server/src/config/ormconfig.ts
+++ b/packages/server/src/config/ormconfig.ts
@@ -12,7 +12,7 @@ export const ormconfig: ConnectionOptions = {
   database: process.env.DB_NAME ?? "db",
   entities: [dir + "entity/*." + extension],
   migrations: [dir + "migration/**/*." + extension],
-  synchronize: process.env.NODE_ENV === "development",
+  synchronize: false,
   logging: false,
   cli: {
     entitiesDir: dir + "entity",

--- a/packages/server/src/entity/User.ts
+++ b/packages/server/src/entity/User.ts
@@ -23,6 +23,9 @@ export class User {
   id: string
 
   @Column()
+  is_anonymous: boolean
+
+  @Column()
   name: string
 
   @Column()

--- a/packages/server/src/handler/file.ts
+++ b/packages/server/src/handler/file.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from "fastify"
 import { File } from "../entity/File"
 import { connection } from "../index"
-import { MultipartFile, MultipartValue } from "fastify-multipart"
+import { MultipartValue } from "fastify-multipart"
 import { ResponseBody } from "../util/schema"
 import {
   buildFileResponse,
@@ -9,10 +9,9 @@ import {
   buildUserResponse,
 } from "../util/responseBuilders"
 import createError from "fastify-error"
-import { ERR_BAD_URL, ERR_INVALID_PAYLOAD } from "../util/errors"
+import { ERR_BAD_URL } from "../util/errors"
 import { registerFirebaseAuth } from "../util/auth"
 import { User } from "../entity/User"
-import { ThumbnailGenerator } from "../thumbnail/ThumbnailGenerator"
 
 export const fileHandler = async (server: FastifyInstance) => {
   await registerFirebaseAuth(server)

--- a/packages/server/src/handler/file.ts
+++ b/packages/server/src/handler/file.ts
@@ -140,8 +140,12 @@ export const fileHandler = async (server: FastifyInstance) => {
       },
     })
 
-    server.thumbnailGenerator().generate(result.id, req.body.file.value)
-    fileModel.thumbnail = `https://${process.env.AWS_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com/thumbnail/${fileModel.id}`
-    await repository.save(fileModel)
+    try {
+      await server.thumbnailGenerator().generate(result.id, req.body.file.value)
+      fileModel.thumbnail = `https://${process.env.AWS_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com/thumbnail/${fileModel.id}`
+      await repository.save(fileModel)
+    } catch (e) {
+      console.error(e)
+    }
   })
 }

--- a/packages/server/src/migration/1636791508938-AddIsAnonymousToUser.ts
+++ b/packages/server/src/migration/1636791508938-AddIsAnonymousToUser.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddIsAnonymousToUser1636791508938 implements MigrationInterface {
+    name = 'AddIsAnonymousToUser1636791508938'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`user\` ADD \`is_anonymous\` tinyint NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`user\` DROP COLUMN \`is_anonymous\``);
+    }
+
+}

--- a/packages/server/src/thumbnail/register.ts
+++ b/packages/server/src/thumbnail/register.ts
@@ -1,12 +1,8 @@
 import { FastifyInstance } from "fastify"
 import { LambdaThumbnailGenerator } from "./lambda"
-import { DummyThumbnailGenerator } from "./dummy"
 
 export const registerThumbnailGenerator = (server: FastifyInstance) => {
-  const generator =
-    process.env.NODE_ENV === "production"
-      ? new LambdaThumbnailGenerator()
-      : new DummyThumbnailGenerator()
+  const generator = new LambdaThumbnailGenerator()
 
   server.decorate("thumbnailGenerator", () => generator)
 }


### PR DESCRIPTION
close #xxx

## やったこと
- Userエンティティに`is_anonymous`を追加し、Firebase Authから取得したUserRecordのnameがnullであれば匿名ユーザーと判断し、`is_anonymous`をtrueにする。また、同じIDで非匿名ユーザーとして再アクセスされたら`name`と`is_anonymous`を更新する。
- 既に非匿名ユーザーとして登録されているユーザーの場合はDBを更新しないようにした。
- `NODE_ENV`に関わらず常にサムネイル機能を有効化した。ローカル環境からでもサムネイル生成できるようにしてたので、その方が良いと思ったという理由。

<!--
### スクリーンショット
-->

<!--
## やっていないこと
-->

<!--
## 動作確認方法
-->

<!--
# 補足・参考リンク
-->