### PR TITLE
スタンプの最初のコメントが反映されないバグを修正

### DIFF
--- a/packages/front/src/components/atoms/Stamp.tsx
+++ b/packages/front/src/components/atoms/Stamp.tsx
@@ -1,5 +1,11 @@
 import type { Stamp as StampModel } from "@domain/stamp"
-import React, { Fragment, useCallback, useEffect, useState } from "react"
+import React, {
+  Fragment,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import { Icon } from "./Icon"
 import { Popover, Transition } from "@headlessui/react"
 import { Play } from "react-feather"
@@ -11,7 +17,7 @@ export type StampProps = {
     comment:
       | { dataType: "audio"; content: Blob; title: string }
       | { dataType: "text"; content: string },
-  ) => void
+  ) => Promise<void>
   isTemporary?: boolean
   onClose?: () => void
 }
@@ -46,11 +52,32 @@ const Stamp: React.VFC<StampProps> = ({
   //   }
   // }, [])
 
-  const buttonRef = useCallback((node: HTMLButtonElement) => {
+  const buttonRef = useRef<HTMLButtonElement | null>(null)
+
+  // const buttonRef = useCallback((node: HTMLButtonElement) => {
+  //   if (isTemporary) {
+  //     node?.click()
+  //   }
+  // }, [])
+  useEffect(() => {
     if (isTemporary) {
-      node?.click()
+      buttonRef.current?.click()
     }
   }, [])
+
+  const handleAddComment = useCallback(
+    async (
+      comment:
+        | { dataType: "audio"; content: Blob; title: string }
+        | { dataType: "text"; content: string },
+    ) => {
+      await onAddComment(comment)
+      if (isTemporary) {
+        buttonRef.current?.click()
+      }
+    },
+    [onAddComment],
+  )
 
   return (
     <Popover className="relative">
@@ -75,7 +102,10 @@ const Stamp: React.VFC<StampProps> = ({
             leaveTo="opacity-0 translate-y-1"
           >
             <Popover.Panel className="absolute z-10 max-w-sm px-4 transform sm:px-0 lg:max-w-3xl max-h-[540px] -translate-x-1/2 left-1/2 mt-4">
-              <Thread comments={stamp.comments} onAddComment={onAddComment} />
+              <Thread
+                comments={stamp.comments}
+                onAddComment={handleAddComment}
+              />
             </Popover.Panel>
           </Transition>
         </>

--- a/packages/front/src/pages/[fileId].tsx
+++ b/packages/front/src/pages/[fileId].tsx
@@ -224,11 +224,11 @@ const FileDetail: NextPage<Record<string, never>, FileDetailQuery> = () => {
                 >
                   <Stamp
                     stamp={stamp}
-                    onAddComment={(comment) => {
+                    onAddComment={async (comment) => {
                       if (isTemporary) {
-                        handleSendCommentAndStamp(stamp, comment)
+                        await handleSendCommentAndStamp(stamp, comment)
                       } else {
-                        handleSendComment(stamp.id, comment)
+                        await handleSendComment(stamp.id, comment)
                       }
                     }}
                     isTemporary={isTemporary}


### PR DESCRIPTION
close #128 

## やったこと
- 新規スタンプにコメントを投稿した後、ポップアップを閉じるようにした
  - （本当は閉じずにコメントを反映させたかったが厳しかったので、とりあえずポッポアップを閉じるようにした）

<!--
### スクリーンショット
-->

<!--
## やっていないこと
-->

<!--
## 動作確認方法
-->

<!--
# 補足・参考リンク
-->